### PR TITLE
docs: add comprehensive codebase documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ This application has been rebuilt using modern web technologies: React, TypeScri
 To build the static application, run:
 `npm run build`
 
+## Documentation
+
+For a deep dive into the project's architecture, APIs, and overall structure, please reference the [docs/README.md](docs/README.md). 
+
+**Rule:** When adding new features or modifying the codebase, documentation must always be updated *first*. Please see the [Workflow Rules in docs/README.md](docs/README.md#development-rules).
+
 ## Project files
 
 - `src/` - React components, hooks, and contexts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# MediaVore Translator Documentation
+
+Welcome to the MediaVore Translator documentation. This folder contains all the necessary information to understand, maintain, and expand the project.
+
+## Development Rules
+
+**CRITICAL RULE: Documentation-First Development**
+When adding or modifying features, you MUST update the documentation in this `docs/` folder FIRST, before writing or committing any code changes. This ensures that the design and intent are explicitly clear and the documentation never falls out of sync with the underlying codebase.
+
+## Documentation Index
+
+- [Architecture & State Management](architecture.md) - High-level overview of the app flow, React Contexts, and major data structures.
+- [API & Services](api.md) - Details on TMDB integration, web scraping behavior, CORS proxies, and data fetching logic.
+- [Component Reference](components.md) - Breakdown of the React UI components, page layouts, and interactive modals.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,22 @@
+# API & Services
+
+The MediaVore Translator interacts with two distinct external service layers: The TMDB database and open web pages via CORS proxies.
+
+## `src/api/tmdb.ts`
+
+Manages all requests natively against the `api.themoviedb.org/3/search/` endpoints.
+
+- **Storage Cached Requests:** Searches are wrapped in a fast `utils/storage.ts` logic layer. Before a network request fires, it checks `tmdb_cache_[type]_[query]_[year]`. If present, it instantaneously resolves it directly from local memory without consuming TMDB rate limits.
+- **Data Normalization:** Movie objects and TV object structures from the API differ natively. The `normalizeResult` helper unifies `release_date`, `first_air_date`, `title`, and `name` fields so `TitleCard.tsx` can consume them generically as a standard typed `TMDBResult`.
+- **Search Types:** Dynamically queries `search/movie` or `search/tv` based on user-provided or auto-detected configurations, passing `include_adult=false`, `language=en-US`, and optionally `primary_release_year` / `first_air_date_year`.
+
+## `src/api/scrape.ts`
+
+Fetches arbitrary HTML from raw URLs to infer media titles. A vital fallback for datasets consisting only of user-shared links.
+
+- **CORS Proxies:** Direct browser-to-browser fetch requests fail on most modern domains due to strict CORS policies. The `scrapeData` function tunnels GET requests through `https://corsproxy.io/?` to fetch full HTML.
+- **Parsing logic:** Uses `DOMParser()` to inflate the HTML text into a virtual `Document`.
+  1. Locates the primary string string utilizing user-provided CSS selectors (e.g. `h1.title`).
+  2. Fallbacks intelligently to standard Open Graph (`<meta property="og:title">`) or standard `<title>` tags if user selectors fail or aren't explicitly provided.
+  3. Pre-cleans common site suffixes identically to how standard URLs appear (e.g., removing `" - IMDb"`, `" — The Movie Database (TMDB)"`, `" - Letterboxd"`).
+- **Year Parsing:** Can optionally target a `yearSelector`. Regex logic (`/\d{4}/`) separates out 4-digit numbers ensuring strict year-formatted outputs without surrounding junk strings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,25 @@
+# Architecture & State Management
+
+MediaVore Translator is built as a single-page React application (SPA). All processing, mapping, data pulling, and exporting occurs entirely locally within the user's browser securely, meaning no user file data ever touches a proprietary backend. External operations are strictly limited to TMDB metadata searches and scraping remote movie/tv profiles for titles.
+
+## High-Level Data Flow
+
+1. **File Ingestion:** The user selects a file (CSV, JSON, YAML). `src/utils/parsers.ts` parses the raw data into a structured array of generic row objects (`parsedFiles`).
+2. **Column Mapping (`SetupPanel.tsx`):** The user interactively maps standard MediaVore fields (Title, Year, Type, Season, Episode) to the columns available in their ingested file. They can specify if the title field is literal text, or a URL that needs scraping.
+3. **Data Distillation:** `MatchContainer.tsx` digests all parsed rows across all loaded files into a streamlined list of *unique* entities (`titlesList`). Duplicates are automatically pruned so each show or movie is only searched once.
+4. **Data Population:**
+   - **Scraping:** If an item is mapped via a URL, `scrapeData` fetches the title using CORS proxies and CSS Selectors.
+   - **TMDB Query:** The resulting entity title and year are queried against the TMDB API.
+5. **Human Review (`TitleCard.tsx`):** If a title resolves unambiguously (or `autoConfirm` is on), the item locks into the `confirmedMap`. Otherwise, the user manually selects the correct match.
+6. **Exportation:** When all unique items hold a validated TMDB match, a final `.mdv` zip containing well-formatted `seen.csv`, `likes.csv`, `notifications.csv`, etc., is generated via `JSZip`.
+
+## State Management (`AppContext.tsx`)
+
+The app avoids Redux or Zustand in favor of native React Context (`AppContext.tsx`), which provides a centralized store for:
+- `parsedFiles`: Collections of raw parsed row data.
+- `fileMappings`: Dictionary mapping file names to their respective column mappings.
+- `confirmedMap`: The ultimate dictionary associating a raw unique title (e.g. "The Matrix::movie") to its verified exact TMDB metadata object.
+- `apiKey`: The user's provided TMDB API key.
+- `autoConfirm`: User setting toggle.
+
+This context ensures `SetupPanel`, `MatchContainer`, and various utility modals all remain naturally synchronized perfectly across rerenders.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,45 @@
+# Components
+
+This document outlines the React component architecture in `src/components/`, designed for simplicity and strict separation of concerns.
+
+## `MatchContainer.tsx`
+
+The core orchestration container that manages the translation list.
+- Calculates and removes duplicates.
+- Generates `titlesList` representing every unique queried title across all files.
+- Uses `useEffect` batch pipelines to asynchronously scrape raw URLs, immediately follow up with TMDB searches (up to 5 items simultaneously), and intelligently pause when rate-limited.
+- Slices rows locally using Pagination (`currentPage`, `pageSize`).
+- Contains the overall `Export Translation` logic that compiles `.csv` sheets via `JSZip`.
+
+## `TitleCard.tsx`
+
+Renders an individual unconfirmed search-validation row.
+- Displays the currently evaluated Title, Year, and Type (Movie/TV).
+- Displays the original scraped URL (demoted visually) if applicable.
+- Conditionally renders `results` from TMDB:
+  - If a scrape fails, displays a detailed error state.
+  - If no TMDB matches occur, shows `No TMDB Matches` with an option to skip.
+  - If matches exist, displays them in a short selectable list.
+- Contains the `Edit Search` sub-component toggle, letting users forcibly rewrite incorrectly mapped or scraped strings manually and dispatching the new search immediately.
+
+## `ScrapeVisualizerModal.tsx`
+
+An interactive sandbox iframe tool allowing users to visually set up DOM queries.
+- Connects to an external URL, safely parses its HTML.
+- Injects a protocol-relative parser to force external CSS/fonts to load effectively.
+- Suppresses native JavaScript execution via `sandbox` tags to block popups/redirects.
+- Allows hovering over elements (using injected classes `.mediavore-hover`, `.mediavore-highlight`) and automatically deduces safe CSS queries (e.g. `h1.title`) to extract text data from user-clicks.
+- Shows live parsed outputs ("Value: The Matrix") so users know their selectors work perfectly.
+
+## `SetupPanel.tsx`
+
+Step 1 of the app. Handles ingesting uploaded file objects via Dropzone logic.
+- Renders the column mapping dropdowns.
+- Differentiates generic text imports from explicit ID/URL mode imports.
+- Conditionally spawns `FieldMapperModal` or `ScrapeVisualizerModal` when advanced configurations are requested.
+
+## `FieldMapperModal.tsx` & `SettingsModal.tsx`
+
+Auxiliary modals ensuring clean UI without bloating standard pages.
+- `SettingsModal.tsx`: Accepts TMDB Keys, Toggle Toggles (Auto Confirm), and local Storage cache clearing.
+- `FieldMapperModal.tsx`: Secondary modal for specific field values (e.g. Series vs Season fields).


### PR DESCRIPTION
Closes #11

This PR introduces an organized `docs` dictionary covering the project's state, UI layouts, and API integrations, empowering future maintainers and developers to ramp up on the codebase intuitively.

## Key Changes:

- Generated `README.md` introducing the new Documentation-First Development workflow rule.
- Added `architecture.md` outlining the high-level single-page conversion architecture and AppContext data flow.
- Added `components.md` documenting the separation of concerns between SetupPanel, `MatchContainer`, `TitleCard`, and interactive modals.
- Added `api.md` explaining the TMDB cache wrapping structure and the implementation of HTML/CORS proxies for web scraping tasks.
- Appended a new Documentation section within the root `README.md` to formally reference these resources directly from the landing developers into the project linking to the new docs.