### PR TITLE
feat: Revamp Media Type Configuration with "Content" Checkboxes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ MediaVore Translator is built as a single-page React application (SPA). All proc
 ## High-Level Data Flow
 
 1. **File Ingestion:** The user selects a file (CSV, JSON, YAML). `src/utils/parsers.ts` parses the raw data into a structured array of generic row objects (`parsedFiles`).
-2. **Column Mapping (`SetupPanel.tsx`):** The user interactively maps standard MediaVore fields (Title, Year, Type, Season, Episode) to the columns available in their ingested file. They can specify if the title field is literal text, or a URL that needs scraping.
+2. **Column Mapping (`SetupPanel.tsx`):** The user interactively maps standard MediaVore fields (Title, Year, Type, Season, Episode) to the columns available in their ingested file. This includes configuring the dataset's "Content" (whether it contains `hasMovies`, `hasSeries`, or both). They can specify if the title field is literal text, or a URL that needs scraping.
 3. **Data Distillation:** `MatchContainer.tsx` digests all parsed rows across all loaded files into a streamlined list of *unique* entities (`titlesList`). Duplicates are automatically pruned so each show or movie is only searched once.
 4. **Data Population:**
    - **Scraping:** If an item is mapped via a URL, `scrapeData` fetches the title using CORS proxies and CSS Selectors.

--- a/docs/components.md
+++ b/docs/components.md
@@ -42,4 +42,4 @@ Step 1 of the app. Handles ingesting uploaded file objects via Dropzone logic.
 
 Auxiliary modals ensuring clean UI without bloating standard pages.
 - `SettingsModal.tsx`: Accepts TMDB Keys, Toggle Toggles (Auto Confirm), and local Storage cache clearing.
-- `FieldMapperModal.tsx`: Secondary modal for specific field values (e.g. Series vs Season fields).
+- `FieldMapperModal.tsx`: Secondary modal for specific field values. It handles the "Content" configuration (toggling Movies and TV Series), dynamically showing conditional inputs like Season/Episode or Media Type values based on whether the dataset contains purely movies, purely series, or a mix of both.

--- a/src/components/FieldMapperModal.tsx
+++ b/src/components/FieldMapperModal.tsx
@@ -220,7 +220,7 @@ export function FieldMapperModal({ fileName, onClose }: { fileName: string, onCl
                             )}
                         </div>
 
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 bg-gray-50 p-4 rounded border border-gray-200">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 bg-gray-50 p-4 rounded border border-gray-200">
                             <div>
                                 <label className="block text-sm font-bold text-gray-700 mb-1">Title or ID (Required)</label>
                                 <select
@@ -240,17 +240,6 @@ export function FieldMapperModal({ fileName, onClose }: { fileName: string, onCl
                                     onChange={e => setLocalMap({ ...localMap, year: e.target.value })}
                                 >
                                     <option value="">-- Select Column --</option>
-                                    {headers.map(h => <option key={h} value={h}>{h}</option>)}
-                                </select>
-                            </div>
-                            <div>
-                                <label className="block text-sm font-bold text-gray-700 mb-1">Media Type</label>
-                                <select
-                                    className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                                    value={localMap.type}
-                                    onChange={e => setLocalMap({ ...localMap, type: e.target.value })}
-                                >
-                                    <option value="">-- Auto-detect --</option>
                                     {headers.map(h => <option key={h} value={h}>{h}</option>)}
                                 </select>
                             </div>
@@ -381,23 +370,37 @@ export function FieldMapperModal({ fileName, onClose }: { fileName: string, onCl
                         </div>
 
                         <div className="border border-gray-200 p-4 rounded">
-                            <label className="flex items-center gap-2 mb-3 cursor-pointer select-none">
-                                <input
-                                    type="checkbox"
-                                    className="w-4 h-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-                                    checked={localMap.hasSeries}
-                                    onChange={e => setLocalMap({ ...localMap, hasSeries: e.target.checked })}
-                                />
-                                <span className="font-bold text-gray-700">Dataset contains TV Series</span>
-                            </label>
+                            <div className="mb-3">
+                                <span className="block text-sm font-bold text-gray-700 mb-2">Content</span>
+                                <div className="flex items-center gap-6">
+                                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                                        <input
+                                            type="checkbox"
+                                            className="w-4 h-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                                            checked={localMap.hasMovies ?? true}
+                                            onChange={e => setLocalMap({ ...localMap, hasMovies: e.target.checked })}
+                                        />
+                                        <span className="font-bold text-gray-700">Movies</span>
+                                    </label>
+                                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                                        <input
+                                            type="checkbox"
+                                            className="w-4 h-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                                            checked={localMap.hasSeries || false}
+                                            onChange={e => setLocalMap({ ...localMap, hasSeries: e.target.checked })}
+                                        />
+                                        <span className="font-bold text-gray-700">TV Series</span>
+                                    </label>
+                                </div>
+                            </div>
 
                             {localMap.hasSeries && (
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2 bg-gray-50 p-3 rounded">
                                     <div>
                                         <label className="block text-sm font-bold text-gray-700 mb-1">Season Column</label>
                                         <select
-                                            className="w-full p-2 border border-gray-300 rounded"
-                                            value={localMap.season} onChange={e => setLocalMap({ ...localMap, season: e.target.value })}
+                                            className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500"
+                                            value={localMap.season || ''} onChange={e => setLocalMap({ ...localMap, season: e.target.value })}
                                         >
                                             <option value="">-- Optional --</option>
                                             {headers.map(h => <option key={h} value={h}>{h}</option>)}
@@ -406,12 +409,67 @@ export function FieldMapperModal({ fileName, onClose }: { fileName: string, onCl
                                     <div>
                                         <label className="block text-sm font-bold text-gray-700 mb-1">Episode Column</label>
                                         <select
-                                            className="w-full p-2 border border-gray-300 rounded"
-                                            value={localMap.episode} onChange={e => setLocalMap({ ...localMap, episode: e.target.value })}
+                                            className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500"
+                                            value={localMap.episode || ''} onChange={e => setLocalMap({ ...localMap, episode: e.target.value })}
                                         >
                                             <option value="">-- Optional --</option>
                                             {headers.map(h => <option key={h} value={h}>{h}</option>)}
                                         </select>
+                                    </div>
+                                </div>
+                            )}
+
+                            {localMap.hasMovies && localMap.hasSeries && (
+                                <div className="mt-4 pt-4 border-t border-gray-200">
+                                    <h4 className="text-sm font-bold text-gray-700 mb-3">Differentiate Movies & Series</h4>
+                                    <div className={`grid grid-cols-1 ${localMap.type ? 'md:grid-cols-3' : 'md:grid-cols-1'} gap-4 bg-gray-50 p-3 rounded text-left`}>
+                                        <div>
+                                            <label className="block text-sm font-bold text-gray-700 mb-1">Media Type Column</label>
+                                            <select
+                                                className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500"
+                                                value={localMap.type || ''}
+                                                onChange={e => setLocalMap({ ...localMap, type: e.target.value })}
+                                            >
+                                                <option value="">-- None --</option>
+                                                {headers.map(h => <option key={h} value={h}>{h}</option>)}
+                                            </select>
+                                        </div>
+                                        {localMap.type && (
+                                            <>
+                                                <div>
+                                                    <label className="block text-sm font-bold text-gray-700 mb-1">Tags for Movies</label>
+                                                    <input
+                                                        type="text"
+                                                        placeholder="e.g. Movie,Film"
+                                                        className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500"
+                                                        value={localMap.typeValues?.movie || ''}
+                                                        onChange={e => setLocalMap({
+                                                            ...localMap,
+                                                            typeValues: {
+                                                                series: localMap.typeValues?.series || 'Serie,TV',
+                                                                movie: e.target.value
+                                                            }
+                                                        })}
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="block text-sm font-bold text-gray-700 mb-1">Tags for Series</label>
+                                                    <input
+                                                        type="text"
+                                                        placeholder="e.g. Serie,TV"
+                                                        className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500"
+                                                        value={localMap.typeValues?.series || ''}
+                                                        onChange={e => setLocalMap({
+                                                            ...localMap,
+                                                            typeValues: {
+                                                                movie: localMap.typeValues?.movie || 'Movie,Film',
+                                                                series: e.target.value
+                                                            }
+                                                        })}
+                                                    />
+                                                </div>
+                                            </>
+                                        )}
                                     </div>
                                 </div>
                             )}

--- a/src/components/MatchContainer.tsx
+++ b/src/components/MatchContainer.tsx
@@ -58,11 +58,16 @@ export function MatchContainer() {
                 t = t.trim();
                 if (!t) return;
 
-                const isTv = currentMapping.hasSeries && (
-                    (currentMapping.type && row[currentMapping.type] && currentMapping.typeValues?.series.includes(row[currentMapping.type])) ||
-                    (currentMapping.season && row[currentMapping.season]) ||
-                    (currentMapping.episode && row[currentMapping.episode])
-                );
+                let isTv = false;
+                if (currentMapping.hasSeries && !currentMapping.hasMovies) {
+                    isTv = true;
+                } else if (currentMapping.hasSeries && currentMapping.hasMovies) {
+                    isTv = !!(
+                        (currentMapping.type && row[currentMapping.type] && currentMapping.typeValues?.series.includes(String(row[currentMapping.type]))) ||
+                        (currentMapping.season && row[currentMapping.season]) ||
+                        (currentMapping.episode && row[currentMapping.episode])
+                    );
+                }
 
                 const typeStr = isTv ? 'tv' : 'movie';
                 
@@ -238,11 +243,16 @@ export function MatchContainer() {
                     const titleStr = typeof titleRaw === 'string' ? titleRaw.trim() : '';
                     if (!titleStr) return;
 
-                    const isTv = currentMapping.hasSeries && (
-                        (currentMapping.type && row[currentMapping.type] && currentMapping.typeValues?.series.includes(row[currentMapping.type])) ||
-                        (currentMapping.season && row[currentMapping.season]) ||
-                        (currentMapping.episode && row[currentMapping.episode])
-                    );
+                    let isTv = false;
+                    if (currentMapping.hasSeries && !currentMapping.hasMovies) {
+                        isTv = true;
+                    } else if (currentMapping.hasSeries && currentMapping.hasMovies) {
+                        isTv = !!(
+                            (currentMapping.type && row[currentMapping.type] && currentMapping.typeValues?.series.includes(String(row[currentMapping.type]))) ||
+                            (currentMapping.season && row[currentMapping.season]) ||
+                            (currentMapping.episode && row[currentMapping.episode])
+                        );
+                    }
 
                     const typeStr = isTv ? 'tv' : 'movie';
                     

--- a/src/components/SetupPanel.tsx
+++ b/src/components/SetupPanel.tsx
@@ -188,7 +188,9 @@ export function SetupPanel({ onFinish }: { onFinish: () => void }) {
                                                                     {map.scrapeUrlColumn ? preview(map.scrapeUrlColumn) : <span className="text-gray-600">Base URL matching ID</span>}
                                                                 </div>
                                                             )}
-                                                            <div><span className="font-bold w-20 inline-block">Type:</span> {preview(map.type)}</div>
+                                                            {map.hasMovies && map.hasSeries && (
+                                                                <div><span className="font-bold w-20 inline-block">Type:</span> {preview(map.type)}</div>
+                                                            )}
                                                             {map.hasSeries && (
                                                                 <>
                                                                     <div><span className="font-bold w-20 inline-block">Season:</span> {preview(map.season)}</div>

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -17,7 +17,7 @@ describe('Storage Mapping Utils', () => {
     const storage = makeStorage();
     const map: FieldMapping = {
       title: 'Name', type: 'Type', season: 'S', episode: 'E', date: 'Date',
-      hasSeries: true, typeValues: null, savedAt: null
+      hasSeries: true, hasMovies: true, typeValues: null, savedAt: null
     };
 
     const ok = saveMapping(map, storage);
@@ -30,13 +30,14 @@ describe('Storage Mapping Utils', () => {
     expect(got.episode).toBe('E');
     expect(got.date).toBe('Date');
     expect(got.hasSeries).toBe(true);
+    expect(got.hasMovies).toBe(true);
   });
 
   it('should export and import mapping', () => {
     const storage = makeStorage();
     const map: FieldMapping = {
       title: 'T', type: '', season: '', episode: '', date: '',
-      hasSeries: false, typeValues: null, savedAt: null
+      hasSeries: false, hasMovies: true, typeValues: null, savedAt: null
     };
 
     saveMapping(map, storage);
@@ -56,6 +57,7 @@ describe('Storage Mapping Utils', () => {
     const map: FieldMapping = {
       title: 'Title', type: 'Type', season: '', episode: '', date: '',
       hasSeries: true,
+      hasMovies: true,
       typeValues: { series: 'Serie,TV', movie: 'Movie,Film' },
       savedAt: null
     };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -12,6 +12,7 @@ export interface FieldMapping {
   date: string;
   order?: string;
   hasSeries: boolean;
+  hasMovies: boolean;
   typeValues: TypeValues | null;
   savedAt: string | null;
   category?: string;
@@ -40,6 +41,7 @@ export const defaultFieldMapping: FieldMapping = {
   date: '',
   order: '',
   hasSeries: false,
+  hasMovies: true,
   typeValues: { series: 'Serie,TV', movie: 'Movie,Film' },
   savedAt: null,
   category: '',
@@ -78,6 +80,7 @@ export function getMapping(storage: Storage = window.localStorage): FieldMapping
       date: storage.getItem(_key('date')) || '',
       order: storage.getItem(_key('order')) || '',
       hasSeries: storage.getItem(_key('has_series')) === '1',
+      hasMovies: storage.getItem(_key('has_movies')) !== '0',
       typeValues: tv,
       category: storage.getItem(_key('category')) || '',
       listNameColumn: storage.getItem(_key('list_name_column')) || '',
@@ -107,6 +110,7 @@ export function saveMapping(map: FieldMapping, storage: Storage = window.localSt
     storage.setItem(_key('date'), map.date || '');
     storage.setItem(_key('order'), map.order || '');
     storage.setItem(_key('has_series'), map.hasSeries ? '1' : '0');
+    storage.setItem(_key('has_movies'), map.hasMovies ? '1' : '0');
     storage.setItem(_key('category'), map.category || '');
     storage.setItem(_key('list_name_column'), map.listNameColumn || '');
     storage.setItem(_key('is_multi_list'), map.isMultiList ? '1' : '0');
@@ -182,6 +186,7 @@ export function importMapping(obj: Partial<FieldMapping>, storage: Storage = win
     date: obj.date || '',
     order: obj.order || '',
     hasSeries: !!obj.hasSeries,
+    hasMovies: obj.hasMovies !== undefined ? !!obj.hasMovies : true,
     typeValues: obj.typeValues || defaultFieldMapping.typeValues,
     category: obj.category || '',
     listNameColumn: obj.listNameColumn || '',


### PR DESCRIPTION
Closes #15 

## Overview

This PR refactors the core mapping configuration by replacing the legacy "Media Type" column dropdown and standalone "Dataset contains TV series" checkbox with a unified "Content" section. It introduces a `hasMovies` boolean flag alongside the existing `hasSeries`, creating a cleaner, condition-based setup flow.

Users now explicitly define the dataset's scope (`Movies`, `TV Series`, or both) and only see configuration fields relevant to their selection.

## Changes Included

1. State & Storage Expansion (`storage.ts`)

  - Added support for the `hasMovies` boolean attribute in the `FieldMapping` interface and `defaultFieldMapping`.
  - Updated `getMapping`, `saveMapping`, and `importMapping` serialization logic to serialize/deserialize `hasMovies` properly.

2. Clean Component Rendering (`FieldMapperModal.tsx`)

  - Replaced old mapping fields with a new "Content" grouping containing "Movies" and "TV Series" checkboxes.
  - Conditional Visibility Logic:
    - Selecting only **Movies** hides `Season`/`Episode` configuration outright.
    - Selecting only **TV Series** hides the string tags and custom type-column logic.
    - Selecting Both unhides the structural type differences, revealing the `Media Type Column` mappings.
  - Changed the default dropdown behavior for Media Type mapping from `-- Auto-detect --` to `-- None --` and made the configuration tags (`Tags for Movies` / `Tags for Series`) hidden completely when no column is selected.

3. Processor Engine Routing (`MatchContainer.tsx` & `SetupPanel.tsx`)

  - Updated `isTv` calculations to account for the boolean combinations of `hasMovies` and `hasSeries`. Only when both checkboxes are tickled will it try to extract logic strictly from the media-type column.
  - Refactored `SetupPanel.tsx` visual preview components to dynamically show/hide the Type and `Season`/`Episode` column mappings depending on what content types the user activated.

4. Testing & Docs

  - Wrote and validated the `hasMovies` attribute inside `storage.test.ts`.
  - Updated the architecture overviews and component descriptions in `architecture.md` and `components.md` to document the new dual-checkbox logic flow.

## Testing Steps

  - Load a `.csv` via the main screen and configure mappings.
  - Try toggling "Movies" and "TV Series" checkboxes off/on; ensure that configuration fields visually appear/disappear according to rule logic.
  - Verify selection tags for Movies and Series render only if the user specifies a particular Media Type Column.
  - Start translation processing with only one selected (e.g. only TV series) to verify automatic classification logic during fetching functions properly scopes the search entirely within TV shows.
  - Run `npm test src/utils` to confirm zero regressions on persistence pipelines.